### PR TITLE
Added better support for 3.5 RPi SPI display on SPI-enabled mcHF

### DIFF
--- a/mchf-eclipse/hardware/uhsdr_board.h
+++ b/mchf-eclipse/hardware/uhsdr_board.h
@@ -31,7 +31,7 @@
 // New lcd defines, ONLY ONE MAY BE SET AT COMPILE TIME
 
 // ALTERNATIVE GROUP START USE_GFX
-#define USE_GFX_ILI9486
+//#define USE_GFX_ILI9486
 //#define USE_DRIVER_RA8875
 //#define USE_GFX_ILI932x
 // ALTERNATIVE GROUP END USE_GFX
@@ -157,7 +157,6 @@
 
 #include "comp.h"
 #include "dac.h"
-//
 
 #include "uhsdr_board_config.h"
 

--- a/mchf-eclipse/support/OVI40-FW.launch
+++ b/mchf-eclipse/support/OVI40-FW.launch
@@ -25,7 +25,7 @@
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
-<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU ARM OpenOCD"/>
+<stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.jtagDevice" value="GNU MCU OpenOCD"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
 <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value="8010000"/>
@@ -52,7 +52,7 @@
 <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="DebugOVI40\fw-ovi40.elf"/>
 <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="mchf-eclipse"/>
 <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
-<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>
+<stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value="ilg.gnuarmeclipse.managedbuild.cross.config.elf.debug.433341838.1123244320"/>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
 <listEntry value="/mchf-eclipse"/>
 </listAttribute>


### PR DESCRIPTION
- Now SPI mode for the 320x480 RPi SPI display works even
  if the SPI modification UI-04-N-025 is present.
- Default display driver is ILI932x (the original driver),
  use USE_GFX_ILI9486 to get the 3.5" (RPi/ILI9486) driver.
- Minor change: OVI40 Debug configuration now uses the OVI40 build configuration